### PR TITLE
Extras require

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,11 @@ We strongly recommend using Anaconda to run Pandashells.  Most of the libraries 
 pandashells come pre-installed with Anaconda, though some tools will require additional
 libraries.
 
-There is no requirements file with pandashells because some of the tools only require
+There are no default requirements with pandashells because some of the tools only require
 the standard library, and there's no sense installing unnecessary packages if you only want
-to use that subset of tools.  If a particular tool encounters a missing dependency, it will
+to use that subset of tools. There are optional requirements specified for the tools that use
+the features `pandas`, `graphics`, and `lomb_scargle`. All of these are also covered by the
+feature `full`. If a particular tool encounters a missing dependency, it will
 gracefully fail with an informative message detailing the steps required for installing
 the missing dependency.
 
@@ -84,17 +86,7 @@ then run the following commands
  conda create -n pandashells python=2.7 anaconda
  . activate pandashells
 
- # seaborn and mpld3 only needed if you want to create plots
- conda install seaborn
- pip install mpld3
-
- # astroML, supersmoother, gatspy only needed if you want to use lomb_scarge tool
- pip install astroML
- pip install supersmoother
- pip install gatspy
-
- # installs all command line tools
- pip install pandashells
+ pip install pandashells[full]
 </code></pre>
 
 * Full python-3 install
@@ -102,17 +94,7 @@ then run the following commands
  conda create -n pandashells python=3.4 anaconda
  . activate pandashells
 
- # seaborn and mpld3 only needed if you want to create plots
- conda install seaborn
- pip install mpld3
- 
- # astroML, supersmoother, gatspy only needed if you want to use lomb_scarge tool
- pip install astroML
- pip install supersmoother
- pip install gatspy
-
- # installs all command line tools
- pip install pandashells
+ pip install pandashells[full]
 </code></pre>
 
 **Important:**  If you want to use pandashells without interactive visualizations

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ linear regression.
   strong multicollinearity or other numerical problems.
   </code></pre>
 
-Further examples of each tool can be seen by running the tools with the -h switch.
+Further examples of each tool can be seen by calling it with the -h switch.
 You are encouraged to fully explore these examples. They highlight how Pandashells
-can be used to significantly imporove your effieciency.
+can be used to significantly improve your efficiency.
 

--- a/setup.py
+++ b/setup.py
@@ -36,25 +36,39 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Topic :: Scientific/Engineering',
     ],
+    # If you add/remove a requirement, please also update full
+    extras_require = {
+        'pandas': ['numpy', 'pandas', 'scipy', 'statsmodels'],
+        'graphics': ['matplotlib', 'mpld3', 'seaborn'],
+        'lomb_scargle': ['astroML', 'supersmoother', 'gatspy'],
+        'full': [
+            'numpy', 'pandas', 'scipy', 'statsmodels',
+            'matplotlib', 'mpld3', 'seaborn',
+            'astroML', 'supersmoother', 'gatspy',
+        ],
+    },
     entry_points={
         'console_scripts': [
-            'p.cdf = pandashells.bin.p_cdf:main',
             'p.config = pandashells.bin.p_config:main',
             'p.crypt = pandashells.bin.p_crypt:main',
-            'p.df = pandashells.bin.p_df:main',
-            'p.facet_grid = pandashells.bin.p_facet_grid:main',
             'p.format = pandashells.bin.p_format:main',
-            'p.hist = pandashells.bin.p_hist:main',
-            'p.linspace = pandashells.bin.p_linspace:main',
-            'p.lomb_scargle = pandashells.bin.p_lomb_scargle:main',
-            'p.merge = pandashells.bin.p_merge:main',
             'p.parallel = pandashells.bin.p_parallel:main',
-            'p.plot = pandashells.bin.p_plot:main',
-            'p.rand = pandashells.bin.p_rand:main',
-            'p.regplot = pandashells.bin.p_regplot:main',
-            'p.regress = pandashells.bin.p_regress:main',
-            'p.example_data = pandashells.bin.p_example_data:main',
-            'p.sig_edit = pandashells.bin.p_sig_edit:main',
+
+            'p.df = pandashells.bin.p_df:main [pandas]',
+            'p.example_data = pandashells.bin.p_example_data:main [pandas]',
+            'p.linspace = pandashells.bin.p_linspace:main [pandas]',
+            'p.merge = pandashells.bin.p_merge:main [pandas]',
+            'p.rand = pandashells.bin.p_rand:main [pandas]',
+            'p.regress = pandashells.bin.p_regress:main [pandas]',
+            'p.sig_edit = pandashells.bin.p_sig_edit:main [pandas]',
+
+            'p.cdf = pandashells.bin.p_cdf:main [graphics]',
+            'p.facet_grid = pandashells.bin.p_facet_grid:main [graphics]',
+            'p.hist = pandashells.bin.p_hist:main [graphics]',
+            'p.plot = pandashells.bin.p_plot:main [graphics]',
+            'p.regplot = pandashells.bin.p_regplot:main [graphics]',
+
+            'p.lomb_scargle = pandashells.bin.p_lomb_scargle:main [lomb_scargle]',
         ],
     }
 )


### PR DESCRIPTION
fixes #25 

The `console_script` labels correspond to names in `extras_require`, and they allow the command to require those packages listed against that key.

https://pythonhosted.org/setuptools/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies

> Extras can be used by a project’s entry points to specify dynamic dependencies. For example, if Project A includes a “rst2pdf” script, it might declare it like this, so that the “PDF” requirements are only resolved if the “rst2pdf” script is run:

So `p.fd` will require numpy, pandas etc but `p.crypt` won't. If you attempt to run `p.df`. without numpy the following occurs 
```
(pandashells)alex@martha:~/src/pandashells$ p.df
Traceback (most recent call last):
  File "/home/alex/src/pandashells/bin/p.df", line 9, in <module>
    load_entry_point('pandashells==0.1.4', 'console_scripts', 'p.df')()
  File "/home/alex/src/pandashells/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 552, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/home/alex/src/pandashells/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2672, in load_entry_point
    return ep.load()
  File "/home/alex/src/pandashells/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2344, in load
    self.require(*args, **kwargs)
  File "/home/alex/src/pandashells/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2361, in require
    items = working_set.resolve(reqs, env, installer)
  File "/home/alex/src/pandashells/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 833, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'numpy' distribution was not found and is required by the application
```